### PR TITLE
test: fixed edit report

### DIFF
--- a/cypress/integration/edit-report.spec.js
+++ b/cypress/integration/edit-report.spec.js
@@ -38,6 +38,12 @@ describe('edit report page', () => {
 
     // next
     cy.findByTestId('next-button').click();
+
+    cy.findByTestId('other-funders')
+      .click()
+      .type('funder one');
+    cy.get('#autocomplete-countries-option-0').click();
+
     cy.findByTestId('next-button').click();
     cy.findByTestId('next-button').click();
     cy.findByTestId('next-button').click();
@@ -46,7 +52,7 @@ describe('edit report page', () => {
     cy.findByTestId('submit-button').click();
 
     // go to report
-    cy.wait(5000);
+    cy.wait(2000);
     cy.findByTestId('dialog-button').click();
 
     // check if title has been updated


### PR DESCRIPTION
[IN-511] The "Other funders" option is new and thus blocked clicking next, I've added standard practice of changing this option so the next button works. (The reports weren't broken on my machine, so IN-511 title can be ignored)

[IN-511]: https://zimmermanzimmerman.atlassian.net/browse/IN-511